### PR TITLE
feat: build multi-library search homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>文件检索中心</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="app-header">
+        <div class="header-top">
+          <div class="title-block">
+            <h1 class="app-title">智能文件检索中心</h1>
+            <p class="app-subtitle">选择参与检索的文件库，精准控制搜索范围</p>
+          </div>
+          <div class="header-actions">
+            <button class="action-button restore-default" type="button">恢复默认库</button>
+            <button class="action-button clear-all" type="button">清除全部</button>
+          </div>
+        </div>
+        <div class="search-area" role="search">
+          <input
+            class="search-input"
+            type="search"
+            placeholder="搜索文档、标题或关键词…"
+            aria-label="搜索内容"
+          />
+          <button class="primary-button" type="button">搜索</button>
+        </div>
+        <div class="selected-summary">
+          <span class="summary-label">当前已选库</span>
+          <div class="selected-chips" id="selectedChips" aria-live="polite"></div>
+        </div>
+      </header>
+      <main class="app-content">
+        <section class="library-section" aria-label="文件库列表">
+          <div class="section-header">
+            <div>
+              <h2 class="section-title">文件库列表</h2>
+              <p class="section-subtitle">勾选需要加入检索的文件库，可按类别折叠或搜索</p>
+            </div>
+            <div class="section-actions">
+              <button class="ghost-button select-visible" type="button">全选可见</button>
+              <button class="ghost-button deselect-visible" type="button">取消可见</button>
+            </div>
+          </div>
+          <div class="library-toolbar">
+            <div class="toolbar-search">
+              <input
+                id="libraryFilterInput"
+                class="toolbar-input"
+                type="search"
+                placeholder="筛选库（名称、标签）…"
+                aria-label="筛选文件库"
+              />
+            </div>
+            <label class="remember-toggle">
+              <input id="rememberPreference" type="checkbox" checked />
+              <span>记住我的选择</span>
+            </label>
+          </div>
+          <div class="library-groups" id="libraryGroups"></div>
+        </section>
+        <aside class="selection-preview" aria-label="已选库预览">
+          <div class="preview-header">
+            <h2 class="preview-title">已选库</h2>
+            <span class="preview-count" id="selectedCount">0</span>
+          </div>
+          <p class="preview-subtitle">调整顺序或点击移除，以快速控制检索范围。</p>
+          <ol class="selected-list" id="selectedList"></ol>
+          <div class="preview-card">
+            <h3>系统推荐</h3>
+            <p>默认启用高频使用的库，确保覆盖关键文档。可随时恢复默认设置。</p>
+          </div>
+          <div class="preview-card">
+            <h3>使用提示</h3>
+            <ul>
+              <li>选择过多的库可能延长检索时间。</li>
+              <li>可以通过顶部按钮快速恢复默认或清除全部。</li>
+              <li>鼠标悬停在库名称旁的“i”图标，可查看库简介。</li>
+            </ul>
+          </div>
+        </aside>
+      </main>
+    </div>
+    <div class="toast-container" id="toastContainer" role="status" aria-live="polite"></div>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,764 @@
+(function () {
+  const LIBRARY_GROUPS = [
+    {
+      id: "business",
+      name: "业务资料",
+      description: "面向销售和客户的产品、方案资料集合。",
+      libraries: [
+        {
+          id: "product-handbook",
+          name: "产品手册库",
+          description: "产品介绍、规格与 FAQ 文档，帮助团队快速了解产品亮点。",
+          tags: ["产品", "市场传播"],
+          recommended: true,
+          defaultSelected: true,
+          documents: 1287,
+          updated: "2024-05-12",
+          owner: "产品市场部",
+          info: "包含标准产品介绍、功能矩阵、竞品对比等销售必备资料。",
+        },
+        {
+          id: "solution-blueprint",
+          name: "解决方案蓝图",
+          description: "按行业整理的解决方案、架构图与落地案例模板。",
+          tags: ["行业方案", "演示材料"],
+          recommended: true,
+          defaultSelected: true,
+          documents: 842,
+          updated: "2024-04-28",
+          owner: "行业解决方案组",
+          info: "覆盖金融、制造、政企等 12 个行业的参考方案，可直接用于客户演示。",
+        },
+        {
+          id: "customer-story",
+          name: "客户案例库",
+          description: "沉淀的客户成功案例、合同附件以及实施复盘文档。",
+          tags: ["客户成功", "复盘"],
+          recommended: false,
+          defaultSelected: false,
+          documents: 563,
+          updated: "2024-03-30",
+          owner: "客户成功团队",
+          info: "包含典型客户的实施背景、成果指标及可复用的复盘模板。",
+        },
+        {
+          id: "pricing-hub",
+          name: "价格与合同资料库",
+          description: "报价单模板、合同范本及审批记录集中归档。",
+          tags: ["报价", "合同"],
+          recommended: false,
+          defaultSelected: false,
+          documents: 312,
+          updated: "2024-05-20",
+          owner: "商务管理部",
+          info: "提供最新的价格策略、折扣政策与标准合同文本。",
+          fresh: true,
+        },
+      ],
+    },
+    {
+      id: "knowledge",
+      name: "知识学习",
+      description: "产品培训、学习资料以及常见问题沉淀。",
+      libraries: [
+        {
+          id: "training-center",
+          name: "培训课程库",
+          description: "线下培训课件、录播视频提炼稿以及考试题库。",
+          tags: ["培训", "学习路径"],
+          recommended: true,
+          defaultSelected: true,
+          documents: 658,
+          updated: "2024-05-01",
+          owner: "学习发展中心",
+          info: "覆盖新员工入职、产品进阶到专家认证的完整培训材料。",
+        },
+        {
+          id: "release-notes",
+          name: "版本更新说明",
+          description: "每次版本发布的更新日志、变更说明与兼容性指引。",
+          tags: ["更新日志", "产品迭代"],
+          recommended: true,
+          defaultSelected: true,
+          documents: 242,
+          updated: "2024-05-21",
+          owner: "研发项目管理办",
+          info: "同步产品近期版本变化，含升级须知与回滚方案。",
+          fresh: true,
+        },
+        {
+          id: "knowledge-qa",
+          name: "知识问答库",
+          description: "常见问题、专家解答与社区讨论精选。",
+          tags: ["FAQ", "即时解答"],
+          recommended: false,
+          defaultSelected: false,
+          documents: 1194,
+          updated: "2024-05-16",
+          owner: "客服支持部",
+          info: "围绕产品使用、部署、集成的高频问题，附最佳实践。",
+        },
+        {
+          id: "live-webinar",
+          name: "直播与宣讲资料",
+          description: "直播回放摘要、宣讲稿与互动问答沉淀。",
+          tags: ["直播", "宣讲"],
+          recommended: false,
+          defaultSelected: false,
+          documents: 188,
+          updated: "2024-04-10",
+          owner: "品牌传播组",
+          info: "便于复用的直播宣讲资料，含重点问题整理。",
+        },
+      ],
+    },
+    {
+      id: "governance",
+      name: "制度流程",
+      description: "管理制度、流程规范与模板归档。",
+      libraries: [
+        {
+          id: "policy-center",
+          name: "制度中心",
+          description: "公司制度、管理办法及合规须知的统一入口。",
+          tags: ["制度", "管理"],
+          recommended: true,
+          defaultSelected: true,
+          documents: 476,
+          updated: "2024-02-15",
+          owner: "行政与法务部",
+          info: "收录各类制度、员工手册、合规须知等权威文件。",
+        },
+        {
+          id: "process-handbook",
+          name: "流程手册库",
+          description: "业务流程图、审批路径和 SOP 文档的集中存放。",
+          tags: ["流程", "审批"],
+          recommended: false,
+          defaultSelected: true,
+          documents: 389,
+          updated: "2024-04-05",
+          owner: "流程优化组",
+          info: "覆盖 30+ 业务流程的执行指引，并附常见异常处理说明。",
+        },
+        {
+          id: "template-space",
+          name: "模板资料库",
+          description: "常用文档模板、表单与检查清单下载。",
+          tags: ["模板", "下载"],
+          recommended: false,
+          defaultSelected: true,
+          documents: 721,
+          updated: "2024-03-22",
+          owner: "运营支持部",
+          info: "包含项目立项、会议纪要、采购等标准模板，可直接使用。",
+        },
+        {
+          id: "compliance-archive",
+          name: "合规与安全库",
+          description: "审计记录、安全合规报告与整改追踪。",
+          tags: ["合规", "安全"],
+          recommended: false,
+          defaultSelected: false,
+          documents: 205,
+          updated: "2024-02-28",
+          owner: "安全合规办",
+          info: "集中存放合规稽查结果、整改计划与安全事件通报。",
+        },
+      ],
+    },
+  ];
+
+  const state = {
+    selectedIds: new Set(),
+    defaultSelectedIds: new Set(),
+  };
+
+  const elements = {};
+  const libraryRefs = new Map();
+  const groupStates = new Map();
+  const numberFormatter = new Intl.NumberFormat("zh-CN");
+
+  function init() {
+    cacheElements();
+    prepareDefaults();
+    renderGroups();
+    updateSelectionUI();
+    applyFilter();
+    bindEvents();
+  }
+
+  function cacheElements() {
+    elements.libraryGroups = document.getElementById("libraryGroups");
+    elements.selectedChips = document.getElementById("selectedChips");
+    elements.selectedList = document.getElementById("selectedList");
+    elements.selectedCount = document.getElementById("selectedCount");
+    elements.filterInput = document.getElementById("libraryFilterInput");
+    elements.selectVisible = document.querySelector(".select-visible");
+    elements.deselectVisible = document.querySelector(".deselect-visible");
+    elements.restoreDefault = document.querySelector(".restore-default");
+    elements.clearAll = document.querySelector(".clear-all");
+    elements.rememberPreference = document.getElementById("rememberPreference");
+    elements.searchButton = document.querySelector(".primary-button");
+    elements.toastContainer = document.getElementById("toastContainer");
+  }
+
+  function prepareDefaults() {
+    LIBRARY_GROUPS.forEach((group) => {
+      group.libraries.forEach((lib) => {
+        if (lib.defaultSelected) {
+          state.defaultSelectedIds.add(lib.id);
+          state.selectedIds.add(lib.id);
+        }
+      });
+    });
+  }
+
+  function renderGroups() {
+    elements.libraryGroups.innerHTML = "";
+    libraryRefs.clear();
+    groupStates.clear();
+
+    const fragment = document.createDocumentFragment();
+
+    LIBRARY_GROUPS.forEach((group) => {
+      const section = document.createElement("section");
+      section.className = "library-group";
+      section.dataset.groupId = group.id;
+
+      const headerButton = document.createElement("button");
+      headerButton.type = "button";
+      headerButton.className = "group-header";
+      headerButton.setAttribute("aria-expanded", "true");
+      headerButton.setAttribute("aria-controls", `group-${group.id}`);
+
+      const headerInfo = document.createElement("div");
+      headerInfo.className = "group-info";
+
+      const groupName = document.createElement("span");
+      groupName.className = "group-name";
+      groupName.textContent = group.name;
+
+      const groupDesc = document.createElement("span");
+      groupDesc.className = "group-description";
+      groupDesc.textContent = group.description;
+
+      headerInfo.append(groupName, groupDesc);
+
+      const headerMeta = document.createElement("div");
+      headerMeta.className = "group-meta";
+
+      const countLabel = document.createElement("span");
+      countLabel.dataset.role = "group-count";
+      countLabel.textContent = `0/${group.libraries.length}`;
+
+      const toggleIcon = document.createElement("span");
+      toggleIcon.className = "group-toggle-icon";
+      toggleIcon.setAttribute("aria-hidden", "true");
+
+      headerMeta.append(countLabel, toggleIcon);
+
+      headerButton.append(headerInfo, headerMeta);
+
+      const body = document.createElement("div");
+      body.className = "group-body";
+      body.id = `group-${group.id}`;
+
+      const groupState = {
+        id: group.id,
+        data: group,
+        section,
+        header: headerButton,
+        body,
+        countLabel,
+        emptyHint: null,
+      };
+
+      headerButton.addEventListener("click", () => toggleGroup(groupState));
+
+      const librariesFragment = document.createDocumentFragment();
+
+      group.libraries.forEach((lib) => {
+        const item = createLibraryItem(groupState, lib);
+        librariesFragment.appendChild(item.element);
+      });
+
+      body.appendChild(librariesFragment);
+
+      const emptyHint = document.createElement("div");
+      emptyHint.className = "group-empty-hint";
+      emptyHint.textContent = "没有匹配的文件库";
+      emptyHint.hidden = true;
+      body.appendChild(emptyHint);
+      groupState.emptyHint = emptyHint;
+
+      section.append(headerButton, body);
+      fragment.appendChild(section);
+      groupStates.set(group.id, groupState);
+    });
+
+    elements.libraryGroups.appendChild(fragment);
+  }
+
+  function createLibraryItem(groupState, lib) {
+    const wrapper = document.createElement("label");
+    wrapper.className = "library-item";
+    wrapper.dataset.libraryId = lib.id;
+    wrapper.dataset.groupId = groupState.id;
+
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.checked = state.selectedIds.has(lib.id);
+    checkbox.dataset.libraryId = lib.id;
+    checkbox.setAttribute("aria-label", `选择${lib.name}`);
+
+    const content = document.createElement("div");
+    content.className = "library-content";
+
+    const titleRow = document.createElement("div");
+    titleRow.className = "library-title-row";
+
+    const nameSpan = document.createElement("span");
+    nameSpan.className = "library-name";
+    nameSpan.textContent = lib.name;
+    titleRow.appendChild(nameSpan);
+
+    if (lib.recommended) {
+      const recommendedBadge = document.createElement("span");
+      recommendedBadge.className = "badge";
+      recommendedBadge.textContent = "推荐";
+      titleRow.appendChild(recommendedBadge);
+    }
+
+    if (!lib.recommended && lib.defaultSelected) {
+      const defaultBadge = document.createElement("span");
+      defaultBadge.className = "badge neutral";
+      defaultBadge.textContent = "默认";
+      titleRow.appendChild(defaultBadge);
+    }
+
+    if (lib.fresh) {
+      const freshBadge = document.createElement("span");
+      freshBadge.className = "badge success";
+      freshBadge.textContent = "刚更新";
+      titleRow.appendChild(freshBadge);
+    }
+
+    const desc = document.createElement("p");
+    desc.className = "library-description";
+    desc.textContent = lib.description;
+
+    const tags = document.createElement("div");
+    tags.className = "library-tags";
+    if (Array.isArray(lib.tags)) {
+      lib.tags.forEach((tag) => {
+        const tagElement = document.createElement("span");
+        tagElement.textContent = tag;
+        tags.appendChild(tagElement);
+      });
+    }
+
+    const meta = document.createElement("div");
+    meta.className = "library-meta";
+
+    const docSpan = document.createElement("span");
+    docSpan.textContent = `${numberFormatter.format(lib.documents)} 篇文档`;
+
+    const updateSpan = document.createElement("span");
+    updateSpan.textContent = formatUpdateTime(lib.updated);
+
+    meta.append(docSpan, updateSpan);
+
+    content.append(titleRow, desc, tags, meta);
+
+    const actions = document.createElement("div");
+    actions.className = "library-item-actions";
+
+    if (lib.owner) {
+      const owner = document.createElement("span");
+      owner.textContent = `负责人 ${lib.owner}`;
+      actions.appendChild(owner);
+    }
+
+    const infoButton = document.createElement("button");
+    infoButton.type = "button";
+    infoButton.className = "info-button";
+    infoButton.textContent = "i";
+    infoButton.title = lib.info;
+    infoButton.setAttribute("aria-label", `${lib.name} 简介`);
+    infoButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (lib.info) {
+        showToast(lib.info);
+      }
+    });
+
+    actions.appendChild(infoButton);
+
+    wrapper.append(checkbox, content, actions);
+
+    if (state.selectedIds.has(lib.id)) {
+      wrapper.classList.add("library-item--selected");
+    }
+
+    libraryRefs.set(lib.id, {
+      id: lib.id,
+      data: lib,
+      groupId: groupState.id,
+      checkbox,
+      element: wrapper,
+      visible: true,
+    });
+
+    return { element: wrapper };
+  }
+
+  function toggleGroup(groupState) {
+    if (!groupState) return;
+    const query = (elements.filterInput?.value || "").trim();
+    if (query.length > 0) {
+      return; // 筛选时保持展开，避免错过结果
+    }
+
+    const willCollapse = !groupState.section.classList.contains("is-collapsed");
+    groupState.section.classList.toggle("is-collapsed", willCollapse);
+    groupState.body.hidden = willCollapse;
+    groupState.header.setAttribute("aria-expanded", String(!willCollapse));
+  }
+
+  function bindEvents() {
+    elements.libraryGroups.addEventListener("change", (event) => {
+      const target = event.target;
+      if (target && target.matches('input[type="checkbox"][data-library-id]')) {
+        const libraryId = target.dataset.libraryId;
+        setLibrarySelected(libraryId, target.checked);
+      }
+    });
+
+    elements.selectedChips.addEventListener("click", (event) => {
+      const chip = event.target.closest(".chip");
+      if (!chip) return;
+      const libraryId = chip.dataset.libraryId;
+      setLibrarySelected(libraryId, false);
+    });
+
+    elements.selectedList.addEventListener("click", (event) => {
+      const button = event.target.closest(".remove-button");
+      if (!button) return;
+      const libraryId = button.dataset.libraryId;
+      setLibrarySelected(libraryId, false);
+    });
+
+    elements.filterInput.addEventListener("input", () => {
+      applyFilter();
+    });
+
+    elements.selectVisible.addEventListener("click", () => {
+      const count = bulkToggleVisible(true);
+      if (count > 0) {
+        updateSelectionUI();
+        showToast(`已加入 ${count} 个文件库`, "success");
+      } else {
+        showToast("当前没有可选的库", "warning");
+      }
+    });
+
+    elements.deselectVisible.addEventListener("click", () => {
+      const count = bulkToggleVisible(false);
+      if (count > 0) {
+        updateSelectionUI();
+        showToast(`已移除 ${count} 个文件库`);
+      } else {
+        showToast("当前没有匹配的库", "warning");
+      }
+    });
+
+    elements.restoreDefault.addEventListener("click", () => {
+      let changed = 0;
+      libraryRefs.forEach((ref) => {
+        const shouldSelect = state.defaultSelectedIds.has(ref.id);
+        if (setLibrarySelected(ref.id, shouldSelect, { silent: true, skipRefresh: true })) {
+          changed += 1;
+        }
+      });
+      updateSelectionUI();
+      showToast("已恢复默认推荐库", "success");
+    });
+
+    elements.clearAll.addEventListener("click", () => {
+      if (state.selectedIds.size === 0) {
+        showToast("当前没有选中的库", "warning");
+        return;
+      }
+      libraryRefs.forEach((ref) => {
+        setLibrarySelected(ref.id, false, { silent: true, skipRefresh: true });
+      });
+      updateSelectionUI();
+      showToast("已清除全部选择");
+    });
+
+    elements.rememberPreference.addEventListener("change", (event) => {
+      const checked = event.target.checked;
+      showToast(checked ? "将记住当前的勾选偏好" : "本次调整不会被记录", checked ? "success" : "warning");
+    });
+
+    elements.searchButton.addEventListener("click", () => {
+      const count = state.selectedIds.size;
+      if (count === 0) {
+        showToast("尚未选择检索范围，可先勾选文件库", "warning");
+        return;
+      }
+      showToast(`将在 ${count} 个库中发起检索`, "success");
+    });
+  }
+
+  function bulkToggleVisible(shouldSelect) {
+    let changed = 0;
+    libraryRefs.forEach((ref) => {
+      if (ref.visible) {
+        if (setLibrarySelected(ref.id, shouldSelect, { silent: true, skipRefresh: true })) {
+          changed += 1;
+        }
+      }
+    });
+    return changed;
+  }
+
+  function applyFilter() {
+    const query = (elements.filterInput?.value || "").trim().toLowerCase();
+    const hasQuery = query.length > 0;
+
+    groupStates.forEach((groupState) => {
+      let visibleCount = 0;
+
+      groupState.data.libraries.forEach((lib) => {
+        const ref = libraryRefs.get(lib.id);
+        if (!ref) return;
+
+        const matches = !hasQuery || matchesFilter(lib, query);
+        ref.visible = matches;
+        ref.element.hidden = !matches;
+        if (matches) {
+          visibleCount += 1;
+        }
+      });
+
+      if (hasQuery) {
+        groupState.section.classList.remove("is-collapsed");
+        groupState.body.hidden = false;
+        groupState.header.setAttribute("aria-expanded", "true");
+      } else if (groupState.section.classList.contains("is-collapsed")) {
+        groupState.body.hidden = true;
+      } else {
+        groupState.body.hidden = false;
+      }
+
+      const noVisible = visibleCount === 0;
+      groupState.section.classList.toggle("is-filter-empty", noVisible);
+      groupState.emptyHint.hidden = !noVisible;
+    });
+  }
+
+  function matchesFilter(lib, query) {
+    const haystack = [lib.name, lib.description, ...(lib.tags || [])]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(query);
+  }
+
+  function setLibrarySelected(libraryId, shouldSelect, options = {}) {
+    const { silent = false, skipRefresh = false } = options;
+    if (!libraryRefs.has(libraryId)) return false;
+
+    const ref = libraryRefs.get(libraryId);
+    const alreadySelected = state.selectedIds.has(libraryId);
+
+    if (alreadySelected === shouldSelect) {
+      return false;
+    }
+
+    if (shouldSelect) {
+      state.selectedIds.add(libraryId);
+    } else {
+      state.selectedIds.delete(libraryId);
+    }
+
+    ref.checkbox.checked = shouldSelect;
+    ref.element.classList.toggle("library-item--selected", shouldSelect);
+
+    if (!skipRefresh) {
+      updateSelectionUI();
+    }
+
+    if (!silent) {
+      const libName = ref?.data?.name || "该库";
+      showToast(`${shouldSelect ? "已加入" : "已移除"}「${libName}」`, shouldSelect ? "success" : undefined);
+    }
+
+    return true;
+  }
+
+  function updateSelectionUI() {
+    updateSelectedChips();
+    updateSelectedList();
+    updateCounts();
+  }
+
+  function updateSelectedChips() {
+    elements.selectedChips.innerHTML = "";
+    const selected = getSelectedLibraries();
+
+    if (selected.length === 0) {
+      const placeholder = document.createElement("span");
+      placeholder.className = "empty-placeholder";
+      placeholder.textContent = "尚未选择文件库";
+      elements.selectedChips.appendChild(placeholder);
+      return;
+    }
+
+    selected.forEach(({ lib }) => {
+      const chip = document.createElement("button");
+      chip.type = "button";
+      chip.className = "chip";
+      chip.dataset.libraryId = lib.id;
+      chip.innerHTML = `
+        <span>${lib.name}</span>
+        <svg viewBox="0 0 12 12" aria-hidden="true">
+          <path d="M9.3 2.7a.75.75 0 0 0-1.06 0L6 4.94 3.76 2.7A.75.75 0 0 0 2.7 3.76L4.94 6 2.7 8.24a.75.75 0 1 0 1.06 1.06L6 7.06 8.24 9.3a.75.75 0 0 0 1.06-1.06L7.06 6 9.3 3.76a.75.75 0 0 0 0-1.06Z" fill="currentColor"></path>
+        </svg>
+        <span class="sr-only">移除 ${lib.name}</span>
+      `;
+      elements.selectedChips.appendChild(chip);
+    });
+  }
+
+  function updateSelectedList() {
+    elements.selectedList.innerHTML = "";
+    const selected = getSelectedLibraries();
+
+    if (selected.length === 0) {
+      const emptyItem = document.createElement("li");
+      emptyItem.className = "selected-item empty";
+      emptyItem.textContent = "暂未选择任何文件库";
+      elements.selectedList.appendChild(emptyItem);
+      return;
+    }
+
+    selected.forEach(({ group, lib }) => {
+      const item = document.createElement("li");
+      item.className = "selected-item";
+
+      const info = document.createElement("div");
+      info.className = "selected-info";
+
+      const name = document.createElement("div");
+      name.className = "selected-name";
+      name.textContent = lib.name;
+
+      const desc = document.createElement("div");
+      desc.className = "selected-desc";
+      desc.textContent = lib.description;
+
+      const meta = document.createElement("div");
+      meta.className = "selected-meta";
+
+      const category = document.createElement("span");
+      category.textContent = group.name;
+
+      const docCount = document.createElement("span");
+      docCount.textContent = `${numberFormatter.format(lib.documents)} 篇文档`;
+
+      const updated = document.createElement("span");
+      updated.textContent = formatUpdateTime(lib.updated);
+
+      meta.append(category, docCount, updated);
+
+      info.append(name, desc, meta);
+
+      const removeButton = document.createElement("button");
+      removeButton.type = "button";
+      removeButton.className = "remove-button";
+      removeButton.dataset.libraryId = lib.id;
+      removeButton.textContent = "移除";
+
+      item.append(info, removeButton);
+      elements.selectedList.appendChild(item);
+    });
+  }
+
+  function updateCounts() {
+    elements.selectedCount.textContent = state.selectedIds.size;
+
+    groupStates.forEach((groupState) => {
+      const total = groupState.data.libraries.length;
+      let count = 0;
+      groupState.data.libraries.forEach((lib) => {
+        if (state.selectedIds.has(lib.id)) {
+          count += 1;
+        }
+      });
+      groupState.countLabel.textContent = `${count}/${total}`;
+      groupState.section.classList.toggle("has-selected", count > 0);
+    });
+  }
+
+  function getSelectedLibraries() {
+    const results = [];
+    LIBRARY_GROUPS.forEach((group) => {
+      group.libraries.forEach((lib) => {
+        if (state.selectedIds.has(lib.id)) {
+          results.push({ group, lib });
+        }
+      });
+    });
+    return results;
+  }
+
+  function formatUpdateTime(dateString) {
+    if (!dateString) return "更新记录缺失";
+    const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) {
+      return `更新 ${dateString}`;
+    }
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffDays <= 0) return "今天更新";
+    if (diffDays === 1) return "1 天前更新";
+    if (diffDays < 7) return `${diffDays} 天前更新`;
+    if (diffDays < 30) {
+      const weeks = Math.round(diffDays / 7);
+      return `${weeks} 周前更新`;
+    }
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `更新 ${month}-${day}`;
+  }
+
+  function showToast(message, type) {
+    if (!elements.toastContainer) return;
+    const toast = document.createElement("div");
+    toast.className = "toast";
+    if (type) {
+      toast.classList.add(type);
+    }
+    toast.textContent = message;
+    elements.toastContainer.appendChild(toast);
+
+    requestAnimationFrame(() => {
+      toast.classList.add("visible");
+    });
+
+    setTimeout(() => {
+      toast.classList.remove("visible");
+      setTimeout(() => {
+        toast.remove();
+      }, 300);
+    }, 2600);
+  }
+
+  document.addEventListener("DOMContentLoaded", init);
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,763 @@
+:root {
+  color-scheme: light;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f4f6fc;
+  --color-border: #e1e8ff;
+  --color-border-strong: #c5d4ff;
+  --color-text-primary: #1b1f36;
+  --color-text-secondary: #5b6c8c;
+  --color-accent: #3b6df6;
+  --color-accent-soft: #e7edff;
+  --color-success: #3cc48f;
+  --shadow-sm: 0 10px 30px rgba(41, 73, 161, 0.08);
+  --shadow-inner: inset 0 0 0 1px rgba(107, 137, 230, 0.15);
+  font-family: "PingFang SC", "Microsoft YaHei", "Noto Sans SC", system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #f1f4fb;
+  color: var(--color-text-primary);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+h1,
+ h2,
+ h3,
+ h4,
+ h5,
+ h6,
+ p,
+ ul,
+ ol {
+  margin: 0;
+  padding: 0;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+input,
+ button {
+  outline: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.app-shell {
+  max-width: 1220px;
+  margin: 0 auto;
+  padding: 2.5rem 2.5rem 3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.app-header {
+  background: var(--color-surface);
+  border-radius: 20px;
+  padding: 2.25rem;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.header-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.app-title {
+  font-size: 1.75rem;
+  font-weight: 600;
+}
+
+.app-subtitle {
+  font-size: 0.95rem;
+  color: var(--color-text-secondary);
+}
+
+.header-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.search-area {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.search-input {
+  flex: 1;
+  padding: 0.85rem 1.25rem;
+  border-radius: 16px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.search-input:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 4px rgba(59, 109, 246, 0.15);
+  background: #fff;
+}
+
+.primary-button {
+  padding: 0.85rem 1.8rem;
+  border-radius: 14px;
+  border: none;
+  background: linear-gradient(130deg, var(--color-accent), #5b8bff);
+  color: #fff;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primary-button:active {
+  transform: translateY(1px);
+}
+
+.primary-button:hover {
+  box-shadow: 0 12px 24px rgba(50, 98, 226, 0.2);
+}
+
+.action-button,
+.ghost-button {
+  padding: 0.6rem 1.1rem;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  background: #fff;
+  color: var(--color-text-secondary);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+}
+
+.action-button:hover,
+.ghost-button:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  box-shadow: 0 6px 16px rgba(59, 109, 246, 0.12);
+}
+
+.action-button:active,
+.ghost-button:active {
+  transform: translateY(1px);
+}
+
+.selected-summary {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.summary-label {
+  font-weight: 600;
+  padding-top: 0.3rem;
+  color: var(--color-text-secondary);
+}
+
+.selected-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  flex: 1;
+  min-height: 2.25rem;
+}
+
+.selected-chips .chip {
+  border: none;
+  border-radius: 999px;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  padding: 0.4rem 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.selected-chips .chip:hover {
+  background: rgba(59, 109, 246, 0.18);
+  transform: translateY(-1px);
+}
+
+.selected-chips .chip svg {
+  width: 12px;
+  height: 12px;
+  display: block;
+  fill: currentColor;
+}
+
+.selected-chips .empty-placeholder {
+  color: var(--color-text-secondary);
+}
+
+.app-content {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+  gap: 1.8rem;
+}
+
+.library-section,
+.selection-preview {
+  background: var(--color-surface);
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.section-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.section-title {
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.section-subtitle {
+  margin-top: 0.25rem;
+  color: var(--color-text-secondary);
+  font-size: 0.93rem;
+}
+
+.section-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.library-toolbar {
+  margin-top: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.toolbar-search {
+  flex: 1;
+}
+
+.toolbar-input {
+  width: 100%;
+  padding: 0.75rem 1.1rem;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.toolbar-input:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 4px rgba(59, 109, 246, 0.12);
+  background: #fff;
+}
+
+.remember-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--color-text-secondary);
+  font-size: 0.92rem;
+}
+
+.remember-toggle input {
+  width: 18px;
+  height: 18px;
+}
+
+.library-groups {
+  margin-top: 1.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.library-group {
+  border-radius: 16px;
+  border: 1px solid var(--color-border);
+  background: #f8faff;
+  overflow: hidden;
+}
+
+.library-group.has-selected {
+  border-color: var(--color-border-strong);
+  box-shadow: var(--shadow-inner);
+}
+
+.group-header {
+  width: 100%;
+  border: none;
+  background: transparent;
+  padding: 1rem 1.4rem;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  cursor: pointer;
+}
+
+.group-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  text-align: left;
+}
+
+.group-name {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.group-description {
+  color: var(--color-text-secondary);
+  font-size: 0.88rem;
+  line-height: 1.4;
+}
+
+.group-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  color: var(--color-text-secondary);
+  font-size: 0.86rem;
+}
+
+.group-toggle-icon {
+  width: 0.75rem;
+  height: 0.75rem;
+  border: solid var(--color-text-secondary);
+  border-width: 0 2px 2px 0;
+  display: inline-block;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.library-group.is-collapsed .group-toggle-icon {
+  transform: rotate(-135deg);
+}
+
+.group-body {
+  padding: 0 1.4rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.library-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 1.1rem;
+  align-items: start;
+  padding: 1rem 1rem;
+  border-radius: 14px;
+  background: #fff;
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.library-item:hover {
+  border-color: var(--color-border-strong);
+  box-shadow: 0 10px 24px rgba(41, 73, 161, 0.12);
+  transform: translateY(-1px);
+}
+
+.library-item--selected {
+  border-color: var(--color-accent);
+  box-shadow: 0 10px 28px rgba(59, 109, 246, 0.18);
+}
+
+.library-item input[type="checkbox"] {
+  width: 20px;
+  height: 20px;
+  margin-top: 0.2rem;
+}
+
+.library-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.library-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.library-name {
+  font-weight: 600;
+}
+
+.badge {
+  font-size: 0.75rem;
+  border-radius: 999px;
+  padding: 0.1rem 0.6rem;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.badge.neutral {
+  background: #eff3ff;
+  color: var(--color-text-secondary);
+}
+
+.badge.success {
+  background: #e7f8f1;
+  color: var(--color-success);
+}
+
+.library-description {
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.library-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+}
+
+.library-meta span::before {
+  content: "•";
+  margin-right: 0.35rem;
+}
+
+.library-meta span:first-child::before {
+  content: "";
+  margin-right: 0;
+}
+
+.library-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+}
+
+.library-tags span {
+  padding: 0.15rem 0.55rem;
+  border-radius: 8px;
+  background: #eef2ff;
+  color: #4a5b85;
+}
+
+.info-button {
+  border: none;
+  background: rgba(59, 109, 246, 0.12);
+  color: var(--color-accent);
+  border-radius: 999px;
+  padding: 0.3rem 0.55rem;
+  font-size: 0.75rem;
+}
+
+.info-button:hover {
+  background: rgba(59, 109, 246, 0.2);
+}
+
+.library-item-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  align-items: flex-end;
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+}
+
+.library-item-actions time {
+  color: var(--color-text-secondary);
+}
+
+.group-empty-hint {
+  display: none;
+  padding: 1rem 1.1rem;
+  color: var(--color-text-secondary);
+  font-size: 0.88rem;
+  border-radius: 12px;
+  border: 1px dashed var(--color-border);
+  background: rgba(94, 126, 213, 0.08);
+}
+
+.library-group.is-filter-empty .group-empty-hint {
+  display: block;
+}
+
+.selection-preview {
+  position: sticky;
+  top: 2rem;
+  align-self: start;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.preview-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.preview-count {
+  min-width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+}
+
+.preview-subtitle {
+  color: var(--color-text-secondary);
+  font-size: 0.93rem;
+}
+
+.selected-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  margin: 0;
+  padding: 0;
+}
+
+.selected-item {
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.selected-item .selected-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.selected-item .selected-name {
+  font-weight: 600;
+}
+
+.selected-item .selected-desc {
+  color: var(--color-text-secondary);
+  font-size: 0.88rem;
+}
+
+.selected-item .selected-meta {
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.selected-item .selected-meta span::before {
+  content: "•";
+  margin-right: 0.3rem;
+}
+
+.selected-item .remove-button {
+  border: none;
+  background: transparent;
+  color: var(--color-accent);
+  font-weight: 600;
+  font-size: 0.9rem;
+  padding: 0.3rem 0.4rem;
+}
+
+.selected-item .remove-button:hover {
+  text-decoration: underline;
+}
+
+.selected-item.empty {
+  justify-content: center;
+  color: var(--color-text-secondary);
+}
+
+.preview-card {
+  border-radius: 16px;
+  border: 1px dashed var(--color-border);
+  background: rgba(64, 99, 200, 0.06);
+  padding: 1.1rem 1.2rem;
+  color: var(--color-text-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.preview-card h3 {
+  font-size: 1rem;
+  color: var(--color-text-primary);
+}
+
+.preview-card ul {
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.toast-container {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 1000;
+}
+
+.toast {
+  min-width: 220px;
+  max-width: 320px;
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  background: var(--color-text-primary);
+  color: #fff;
+  box-shadow: 0 16px 30px rgba(12, 23, 49, 0.25);
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  font-size: 0.92rem;
+}
+
+.toast.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast.success {
+  background: #2f9a6d;
+}
+
+.toast.warning {
+  background: #f29a2e;
+}
+
+@media (max-width: 1080px) {
+  .app-shell {
+    padding: 2rem 1.5rem 2.5rem;
+  }
+
+  .app-content {
+    grid-template-columns: 1fr;
+  }
+
+  .selection-preview {
+    position: static;
+  }
+}
+
+@media (max-width: 768px) {
+  .app-header {
+    padding: 1.8rem 1.5rem;
+  }
+
+  .header-top {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .header-actions {
+    justify-content: flex-start;
+  }
+
+  .search-area {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .primary-button {
+    width: 100%;
+  }
+
+  .selected-summary {
+    flex-direction: column;
+  }
+
+  .section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .section-actions {
+    width: 100%;
+  }
+
+  .section-actions button {
+    flex: 1;
+  }
+
+  .library-item {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .library-item-actions {
+    display: none;
+  }
+
+  .toast-container {
+    right: 1rem;
+    left: 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  body {
+    font-size: 15px;
+  }
+
+  .app-shell {
+    padding: 1.5rem 1rem 2rem;
+  }
+
+  .library-section,
+  .selection-preview {
+    padding: 1.5rem 1.2rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add an index page that follows the proposed library-search layout with header, search bar, and selection summary
- implement responsive styling for grouped library cards, chips, preview panel, and toast feedback
- wire up JavaScript for library data, filtering, selection management, bulk actions, and contextual toasts

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d13d5c47548321bd6a2b67ef823c34